### PR TITLE
Arrays & msvc-debug build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ bin/*
 *~
 *.un~
 *.exe
+*.pdb
+*.obj
+edit

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ CXXFLAGS_DEBUG := -O0 -g -std=c++11 -Wall -ggdb3
 
 VALGRIND := valgrind
 
-BIN_PATH := bin
+BIN_PATH := ./bin/
+OBJ_PATH := ./obj/
 BIN_DEBUG_PATH := bin/debug
 SRC_PATH := src
 GC_PATH := src/garbage_collector
@@ -23,6 +24,7 @@ ifeq ($(OS),Windows_NT)
 endif
 
 SOURCE_FILES := $(wildcard $(SRC_PATH)/*.cpp) $(wildcard $(GC_PATH)/*.cpp) $(wildcard $(SRC_PARSER_PATH)/*.cpp) $(wildcard $(DEBUG_PATH)/*.cpp) $(wildcard $(MEMORY_PATH)/*.cpp)
+
 
 workflow:
 # --> Linux 
@@ -52,9 +54,28 @@ windows:
 
 	@python3 progress_bar.py $(CXX) -o $(TARGET) $(SOURCE_FILES) $(CXXFLAGS)
 
-windows-msvc:
-	cl.exe /Fe:zura.exe $(SOURCE_FILES) /EHsc
-
 valgrind:
 	@echo Checking for memory leaks
 	$(VALGRIND) -v --leak-check=full --show-leak-kinds=all bin/zura > --log-file=valgrind.log 2>&1
+
+# For x64-windows only
+# Build then Link
+OBJ_FILES    := $(wildcard $(OBJ_PATH)*.obj) $(wildcard $(OBJ_PATH)*.o)
+PDB_FILES    := $(wildcard *.pdb)
+EXE_FILES    := $(wildcard $(BIN_PATH)*.exe)
+LIB_FILES    := $(wildcard *.lib)
+CLEAN_FILES  := $(OBJ_FILES) $(PDB_FILES) $(EXE_FILES) $(LIB_FILES)
+
+.PHONY: x64-windows-clean x64-windows-debug x64-windows-clean
+
+x64-windows-debug:
+
+	cl.exe /Od /EHsc /fsanitize=address /Zi /Fo:$(OBJ_PATH) /c $(SOURCE_FILES) 
+	cl.exe /Od /EHsc /fsanitize=address /Zi $(OBJ_FILES) /Fe:$(BIN_PATH)zura-debug.exe $(SOURCE_FILES) 
+
+x64-windows-release:
+	cl.exe /O2 /EHsc /Fo:$(OBJ_PATH) /c $(SOURCE_FILES) 
+	cl.exe /Od /EHsc  $(OBJ_FILES) /Fe:$(BIN_PATH)zura.exe $(SOURCE_FILES) 
+
+x64-windows-clean: 
+	@$(RM) $(CLEAN_FILES)

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/src/parser/vm.cpp
+++ b/src/parser/vm.cpp
@@ -8,6 +8,7 @@
 #include <unordered_set>
 #include <vector>
 #include <string>
+#include <stdint.h>
 
 #include "../common.h"
 #include "../debug/debug.h"
@@ -492,10 +493,11 @@ static InterpretResult run() {
     }
     // Array operation codes
     case OP_ARRAY: {
+      
       uint8_t num_elements = read_byte();
-
-      int num_array[num_elements];
-      string str_array[num_elements];
+      
+      int    num_array[UINT8_MAX] = {};
+      string str_array[UINT8_MAX] = {};
 
       // Check the type of each element and store them in separate arrays
       for (int i = 0; i < num_elements; i++) {

--- a/test/main.zu
+++ b/test/main.zu
@@ -1,1 +1,9 @@
+// This is a comment!
+
+func fig(s) {
+  return s + 2; 
+}
 have x := [1, 10, 3];
+have y := "this is a string with a nested (5*3)";
+
+info fig(3);


### PR DESCRIPTION
Set OP_ARRAY in vm.cpp to use full uint8_t size at 256 bytes. This avoids the VLA problem from GCC extensions.

Debug build using msvc on x64-windows expanded to full debugging symbols to be able to step through code on Windows debuggers.