### PR TITLE
Added Zura Exit codes and ZuraExit function.

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+#include "common.h"
+
+void ZuraExit(Zura_Exit_Value exit_value)
+{
+    exit( Zura_Exit_Value(exit_value) );    
+};

--- a/src/common.h
+++ b/src/common.h
@@ -16,7 +16,6 @@
  *****************************************************************************/
 #pragma once
 
-#include <stdbool.h>
 #include <stdint.h>
 
 #define DEBUG_STRESS_GC
@@ -28,3 +27,30 @@
 #define DEBUG_PRINT_CODE
 
 #define UINT8_COUNT (UINT8_MAX + 1)
+
+
+
+/// Exit codes used in the Zura Interpreter.
+///
+/// Add additional exit codes to this list whenever an appropriate
+/// reason is encountered to do so. 
+///
+/// @sa ZuraExit
+typedef enum {
+
+    OK = 0,
+
+    INVALID_FILE_EXTENSION = 10,
+    INVALID_FILE           = 11,
+    COMPILATION_ERROR      = 12,
+    RUNTIME_ERROR          = 13,
+    BAD_GRAY_STACK         = 14,
+    MEMORY_FAILURE         = 15,
+    VM_ERROR               = 16
+
+} Zura_Exit_Value;
+
+/// Exits the Zura interpreter using an appropriate exit value.
+/// @param exit_value An exit value specific to the Zura interpreter code base.
+/// @sa Zura_Exit_Value
+void ZuraExit(Zura_Exit_Value exit_value);

--- a/src/garbage_collector/gc.cpp
+++ b/src/garbage_collector/gc.cpp
@@ -27,8 +27,9 @@ void mark_object(Obj* object) {
         vm.gray_capacity = GROW_CAPACITY(vm.gray_capacity);
         vm.gray_stack = (Obj**)realloc(vm.gray_stack, sizeof(Obj*) + vm.gray_capacity);
 
-        if
-        (vm.gray_stack == nullptr) exit(1);
+        if(vm.gray_stack == nullptr){
+            ZuraExit(BAD_GRAY_STACK);
+        }
     }
     vm.gray_stack[vm.gray_count++] = object;
 }

--- a/src/helper/errors.h
+++ b/src/helper/errors.h
@@ -63,5 +63,5 @@ inline void runtimeError(const char *format, ...) {
   vfprintf(stderr, format, args);
   va_end(args);
   fputs("\n", stderr);
-  exit(1);
+  ZuraExit(RUNTIME_ERROR);
 }

--- a/src/helper/flags.h
+++ b/src/helper/flags.h
@@ -2,10 +2,13 @@
 #include "./getCurrentTime.h"
 #include "./repl.h"
 #include "./version.h"
+#include "common.h"
+
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
 using namespace std;
 
 static char *read_file(const char *path) {
@@ -20,7 +23,7 @@ static char *read_file(const char *path) {
   ifstream file(path, ios::binary);
   if (!file) {
     cerr << "Could not open file \"" << path << "\"." << endl;
-    exit(74);
+    ZuraExit(INVALID_FILE);
   }
 
   file.seekg(0, ios::end);
@@ -36,19 +39,22 @@ static char *read_file(const char *path) {
 }
 
 inline void run_file(const char *path) {
-  const char *source = read_file(path);
-  // Check to make sure that we have  a .zu file extension
-  if (strcmp(path + strlen(path) - 3, ".zu") != 0) {
-    cerr << "File \"" << path << "\" does not have a .zu extension." << endl;
-    exit(65);
-  }
+
+    const char *source = read_file(path);
+
+    // Check to make sure that we have  a .zu file extension
+    if (strcmp(path + strlen(path) - 3, ".zu") != 0) {
+        cerr << "File \"" << path << "\" does not have a .zu extension." << endl;
+        ZuraExit(INVALID_FILE_EXTENSION);
+    }
 
   InterpretResult result = interpret(source);
 
-  if (result == InterpretResult::INTERPRET_COMPILE_ERROR)
-    exit(65);
-  else if (result == InterpretResult::INTERPRET_COMPILE_ERROR)
-    exit(70);
+  if (result == InterpretResult::INTERPRET_COMPILE_ERROR){
+    ZuraExit(COMPILATION_ERROR);
+  }
+
+
 }
 
 inline void flags(int argc, char *argv[]) {
@@ -59,17 +65,17 @@ inline void flags(int argc, char *argv[]) {
     cout << "  --help\t\t\tPrints this help message" << endl;
     cout << "  --version\t\t\tPrints the version of the compiler" << endl;
     cout << "  --license\t\t\tPrints the license of the Zura Lang" << endl;
-    exit(0);
+    ZuraExit(OK);
   }
 
   if (argc == 2 && strcmp(argv[1], "--version") == 0) {
     cout << get_Zura_version_string() << "(" << getCurrentTime() << ")" << endl;
-    exit(0);
+    ZuraExit(OK);
   }
   if (argc == 2 && strcmp(argv[1], "--license") == 0) {
     cout << "Zura Lang is licenesed under GPL-3.0 "
             "license(https://www.gnu.org/licenses/gpl-3.0.en.html) "
          << endl;
-    exit(0);
+    ZuraExit(OK);
   }
 }

--- a/src/memory/memory.cpp
+++ b/src/memory/memory.cpp
@@ -21,7 +21,7 @@ void *reallocate(void *pointer, size_t old_size, size_t new_size) {
   void *new_pointer = realloc(pointer, new_size);
   if (new_pointer == nullptr){
     cerr << "ERROR: Failed to reallocate memory.\n";
-    exit(1);
+    ZuraExit(MEMORY_FAILURE);
   }
   return new_pointer;
 }

--- a/src/parser/chunk.cpp
+++ b/src/parser/chunk.cpp
@@ -5,10 +5,11 @@
 #include "chunk.h"
 
 void init_chunk(Chunk *chunk) {
-  chunk->lines = nullptr;
-  chunk->code = nullptr;
+
+  chunk->lines    = nullptr;
+  chunk->code     = nullptr;
   chunk->capacity = 0;
-  chunk->count = 0;
+  chunk->count    = 0;
 
   init_value_array(&chunk->constants);
 }

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -286,7 +286,7 @@ ObjModule *load_module(ObjString *name) {
     }
     errorMessage += "'";
     runtimeError(errorMessage.c_str(), circularDependence.size());
-    exit(1);
+    ZuraExit(VM_ERROR);
   }
 
   loadedModules.insert(name);
@@ -303,7 +303,7 @@ ObjModule *load_module(ObjString *name) {
     errorMessage += moduleFileName;
     errorMessage += "'";
     runtimeError(errorMessage.c_str());
-    exit(1);
+    ZuraExit(VM_ERROR);
   }
 
   std::vector<char> buffer;
@@ -318,7 +318,7 @@ ObjModule *load_module(ObjString *name) {
   InterpretResult result = interpret(source.c_str());
   if (result != INTERPRET_OK) {
     runtime_error("Error loading module!");
-    exit(1);
+    ZuraExit(VM_ERROR);
   }
 
   // Finished loading the module, remove it from loadingModules


### PR DESCRIPTION
Exit codes can be helpful to know why a program ended. When the interpreter finds some kind of fault and calls exit(), the resulting exit codes haven't been very helpful. Now we can use a list of values to as a reference for to help understand why the interpreter faulted.